### PR TITLE
ci: enable corepack for yarn 4 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
## Summary

- Add `corepack enable` step before `yarn install --immutable`
- Fixes deploy failure: system yarn 1.22.22 doesn't support packageManager field

Closes #3