### PR TITLE
feat: add /api/geo endpoint for Cloudflare-based EU detection

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,9 @@ compatibility_date = "2024-12-01"
 # Each domain gets its own KV prefix for isolation
 routes = [
   { pattern = "gitlab-mcp.sw.foundation/api/consent*", zone_name = "sw.foundation" },
-  { pattern = "privacy.sw.foundation/api/consent*", zone_name = "sw.foundation" }
+  { pattern = "gitlab-mcp.sw.foundation/api/geo", zone_name = "sw.foundation" },
+  { pattern = "privacy.sw.foundation/api/consent*", zone_name = "sw.foundation" },
+  { pattern = "privacy.sw.foundation/api/geo", zone_name = "sw.foundation" },
 ]
 
 # KV namespace for consent storage (365 days TTL)


### PR DESCRIPTION
## Summary

- Add `GET /api/geo` endpoint returning `{ isEU, countryCode, continent, method: "worker" }` from `request.cf`
- Add route patterns for `/api/geo` on both sw.foundation domains
- No KV storage needed — pure geo-detection from Cloudflare edge

## Usage

```bash
curl https://privacy.sw.foundation/api/geo
# {"isEU":false,"countryCode":"US","continent":"NA","method":"worker"}
```

## Test plan

- [x] `yarn typecheck` passes
- [ ] Deploy and verify: `curl https://privacy.sw.foundation/api/geo`

Closes #9