### PR TITLE
feat: add coordinode-docs.sw.foundation consent storage endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,14 @@ const ALLOWED_DOMAINS: Record<string, string[]> = {
     "http://localhost:5173",
     "http://localhost:4173",
   ],
+  // Consent storage for docs.coordinode.com — routed via coordinode-docs.sw.foundation
+  // because coordinode.com DNS is on PowerDNS (not Cloudflare), so we can't add
+  // zone routes for it directly. This subdomain is in the sw.foundation CF zone.
+  "coordinode-docs.sw.foundation": [
+    "https://docs.coordinode.com",
+    "http://localhost:5173",
+    "http://localhost:4173",
+  ],
 };
 
 export default {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,6 +11,10 @@ routes = [
   { pattern = "gitlab-mcp.sw.foundation/api/geo", zone_name = "sw.foundation" },
   { pattern = "privacy.sw.foundation/api/consent*", zone_name = "sw.foundation" },
   { pattern = "privacy.sw.foundation/api/geo", zone_name = "sw.foundation" },
+  # CoordiNode docs — coordinode.com DNS is on PowerDNS (not Cloudflare),
+  # so we proxy API through this sw.foundation subdomain instead.
+  { pattern = "coordinode-docs.sw.foundation/api/consent*", zone_name = "sw.foundation" },
+  { pattern = "coordinode-docs.sw.foundation/api/geo", zone_name = "sw.foundation" },
 ]
 
 # KV namespace for consent storage (365 days TTL)


### PR DESCRIPTION
## Summary
- Add `coordinode-docs.sw.foundation` to `ALLOWED_DOMAINS` with `https://docs.coordinode.com` as allowed CORS origin
- Add wrangler routes for `/api/consent*` and `/api/geo`

## Why a subdomain proxy?
`coordinode.com` DNS is on PowerDNS (not Cloudflare), so Cloudflare Worker zone routes for `docs.coordinode.com` are impossible. `coordinode-docs.sw.foundation` (in the `sw.foundation` CF zone) acts as API proxy — same pattern as `gitlab-mcp.sw.foundation` and `privacy.sw.foundation`.

DNS record already created: `coordinode-docs.sw.foundation CNAME structured-world.github.io (proxied)`.

Closes #53